### PR TITLE
fix: 使 ProjectArea 依據 pathname 的不同進行 fetch

### DIFF
--- a/src/pages/ProjectArea.tsx
+++ b/src/pages/ProjectArea.tsx
@@ -7,6 +7,7 @@ import useProjectFetch from '@/hooks/useProjectFetch';
 import { useAuth } from '@/context/AuthContext';
 import GanttChart from '@/components/GanttChart';
 import LazyMe from '@/components/LazyMe';
+import { useLocation } from 'react-router-dom';
 
 const ProjectArea = () => {
   const [viewMode, setViewMode] = useState<number>(1);
@@ -14,24 +15,24 @@ const ProjectArea = () => {
   const [reloadProjectData, setReloadProjectData] = useState<boolean>(false);
   const { data, isLoading, setRequest } = useProjectFetch();
   const { currentUser } = useAuth();
+  const location = useLocation();
 
   const getProjectData = () => {
-    if (activeProject) {
-      setRequest({
-        uId: currentUser.uid,
-        projectId: activeProject!.id,
-        method: 'GET',
-        accessToken: currentUser.accessToken,
-      });
-    }
+    const projectIdFromLocation: string = location.pathname.replace(/^\//, '');
+    setRequest({
+      uId: currentUser.uid,
+      projectId: projectIdFromLocation,
+      method: 'GET',
+      accessToken: currentUser.accessToken,
+    });
     setReloadProjectData(false);
   }
 
   useEffect(() => {
     getProjectData();
-  }, []);
+  }, [location.pathname]);
   
-  useEffect(() => console.log('data', data), [data])
+  // useEffect(() => console.log('location', location.pathname), [data])
 
   useEffect(() => {
     if (reloadProjectData) {


### PR DESCRIPTION
原本的問題：
1. Project 相關 data 並未更新，殘存前一頁面的 data
2. 使用者每次想拿到 Project 相關 data，都得先點擊回去 Dashboard，接著再點擊回 Project 頁面，才能拿到相關 data。

原因：
- 原本透過 activedProject 的方式來拿到專案名稱、ID，而 ProjectArea 在拿到 Project ID 前，就會進行 fetch（也就是拿 null 值 fetch），故導致此問題。

解決方法：
- 透過 react-router-dom 內建的 useLocation 功能，拿到目前的 pathname，由於 pathname 為 Project ID，因此透過這一方法能讓使用者點擊 Project 頁面時，馬上 fetch 拿到 Project 相關 data
- 再加上 useEffect 監聽，每當 pathname 改變時，就會重新 fetch 一次，故能解決上一頁面 data 殘存問題。